### PR TITLE
Add Android skeleton and permissions docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
 # Elderly-AI
 
-This will be an AI assistant for the elderly that can check it on a schedule.
+This project aims to build an AI assistant that can periodically check in on a
+user via scheduled voice calls. The new Android module (`app`) demonstrates the
+permissions required to wake the device and start a voice chat.
+
+See `docs/permissions.md` for a description of each permission.

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,0 +1,33 @@
+plugins {
+    id("com.android.application")
+    kotlin("android")
+}
+
+android {
+    namespace = "com.example.elderlyai"
+    compileSdk = 34
+
+    defaultConfig {
+        applicationId = "com.example.elderlyai"
+        minSdk = 26
+        targetSdk = 34
+        versionCode = 1
+        versionName = "1.0"
+    }
+
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
+    }
+    kotlinOptions {
+        jvmTarget = "17"
+    }
+}
+
+dependencies {
+    implementation("androidx.core:core-ktx:1.13.1")
+    implementation("androidx.appcompat:appcompat:1.6.1")
+    implementation("com.google.android.material:material:1.12.0")
+    implementation("androidx.activity:activity-compose:1.9.0")
+    implementation("androidx.compose.material3:material3:1.2.1")
+}

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,0 +1,32 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="com.example.elderlyai">
+
+    <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.RECORD_AUDIO" />
+    <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
+    <uses-permission android:name="android.permission.WAKE_LOCK" />
+    <uses-permission android:name="android.permission.SCHEDULE_EXACT_ALARM" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
+    <uses-permission android:name="android.permission.BIND_ACCESSIBILITY_SERVICE" />
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
+
+    <application
+        android:allowBackup="true"
+        android:label="@string/app_name"
+        android:theme="@style/Theme.ElderlyAI">
+
+        <activity android:name=".MainActivity">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+        </activity>
+
+        <service
+            android:name=".ScheduleService"
+            android:exported="false"
+            android:permission="android.permission.BIND_ACCESSIBILITY_SERVICE" />
+
+    </application>
+
+</manifest>

--- a/app/src/main/java/com/example/elderlyai/MainActivity.kt
+++ b/app/src/main/java/com/example/elderlyai/MainActivity.kt
@@ -1,0 +1,15 @@
+package com.example.elderlyai
+
+import android.os.Bundle
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+import androidx.compose.material3.Text
+
+class MainActivity : ComponentActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContent {
+            Text("Elderly AI placeholder")
+        }
+    }
+}

--- a/app/src/main/java/com/example/elderlyai/ScheduleService.kt
+++ b/app/src/main/java/com/example/elderlyai/ScheduleService.kt
@@ -1,0 +1,12 @@
+package com.example.elderlyai
+
+import android.app.Service
+import android.content.Intent
+import android.os.IBinder
+
+/**
+ * Placeholder service that would schedule and launch voice chats.
+ */
+class ScheduleService : Service() {
+    override fun onBind(intent: Intent?): IBinder? = null
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,0 +1,3 @@
+<resources>
+    <string name="app_name">Elderly AI</string>
+</resources>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -1,0 +1,5 @@
+<resources xmlns:tools="http://schemas.android.com/tools">
+    <style name="Theme.ElderlyAI" parent="android:Theme.Material">
+        <!-- Customize the app theme here. -->
+    </style>
+</resources>

--- a/docs/permissions.md
+++ b/docs/permissions.md
@@ -1,0 +1,22 @@
+# Android permissions for scheduled voice chat
+
+To automatically check in on a user and start a voice chat the application needs
+a variety of permissions:
+
+| Permission | Purpose |
+|------------|---------|
+| `RECORD_AUDIO` | Capture the user's voice so it can be transcribed and sent to the AI. |
+| `INTERNET` | Reach the OpenAI API to initiate voice chat or send transcriptions. |
+| `RECEIVE_BOOT_COMPLETED` | Re-schedule alarms or background workers when the device restarts. |
+| `WAKE_LOCK` | Temporarily wake and keep the device active when a scheduled check in fires. |
+| `SCHEDULE_EXACT_ALARM` | Set exact alarms on Android 12+ so the device can wake at a specific time. |
+| `FOREGROUND_SERVICE` | Run a foreground service that listens in the background without being killed. |
+| `BIND_ACCESSIBILITY_SERVICE` | Provide accessibility features allowing the app to interact even if the user cannot reach the phone. |
+| `POST_NOTIFICATIONS` | Notify the user about scheduled calls on newer Android versions. |
+
+Some manufacturers also require `REQUEST_IGNORE_BATTERY_OPTIMIZATIONS` so the
+service is not killed, though this is requested at runtime rather than declared
+in the manifest.
+
+These permissions are reflected in the `AndroidManifest.xml` inside the `app`
+module.

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -14,3 +14,5 @@ pluginManagement {
 }
 
 rootProject.name = "Elderly-AI"
+
+include(":app")


### PR DESCRIPTION
## Summary
- add documentation for Android permissions
- create `app` module with manifest and skeleton source
- include new module in Gradle settings
- update README to mention permissions doc

## Testing
- `gradle help` *(fails: plugin not found because dependencies can't be downloaded)*

------
https://chatgpt.com/codex/tasks/task_e_687410bcc2c8832ca17d13ba534b8410