### PR TITLE
Refactor device agent structure

### DIFF
--- a/device/src/ble_onboarding.py
+++ b/device/src/ble_onboarding.py
@@ -6,6 +6,8 @@ from bleak import BleakServer
 from bleak.backends.characteristic import BleakGATTCharacteristic
 from bleak.backends.service import BleakGATTService
 
+from .models import OnboardingState
+
 logger = structlog.get_logger()
 
 ONBOARDING_SERVICE_UUID = "0000FFF0-0000-1000-8000-00805F9B34FB"
@@ -14,16 +16,6 @@ PSK_CHAR_UUID = "0000FFF2-0000-1000-8000-00805F9B34FB"
 TIMEZONE_CHAR_UUID = "0000FFF3-0000-1000-8000-00805F9B34FB"
 CLAIM_TOKEN_CHAR_UUID = "0000FFF4-0000-1000-8000-00805F9B34FB"
 STATUS_CHAR_UUID = "0000FFF5-0000-1000-8000-00805F9B34FB"
-
-class OnboardingState:
-    def __init__(self):
-        self.ssid = None
-        self.psk = None
-        self.timezone = None
-        self.claim_token = None
-
-    def is_complete(self):
-        return all([self.ssid, self.psk, self.timezone, self.claim_token])
 
 state = OnboardingState()
 

--- a/device/src/firebase_client.py
+++ b/device/src/firebase_client.py
@@ -3,6 +3,8 @@ import structlog
 import firebase_admin
 from firebase_admin import credentials, firestore
 
+from .models import Schedule
+
 logger = structlog.get_logger()
 
 def initialize_firebase():
@@ -23,16 +25,18 @@ def initialize_firebase():
         return False
 
 def listen_for_schedules(callback):
+    """Listens for changes to schedules in Firestore.
+
+    A real implementation would attach a snapshot listener and construct
+    :class:`Schedule` objects from Firestore documents. For now a single
+    ``Schedule`` instance is synthesised and ``callback`` is invoked with
+    it to simulate behaviour.
     """
-    Listens for changes to the schedules in Firestore.
-    This is a placeholder implementation.
-    """
+
     logger.info("Listening for schedule changes...")
-    # In a real implementation, you would use a Firestore snapshot listener.
-    # For now, we'll just call the callback with a dummy schedule.
-    dummy_schedule = {
-        "id": "daily_checkin",
-        "cron": "0 9 * * *",
-        "promptVariant": "daily_checkin_v1"
-    }
+    dummy_schedule = Schedule(
+        id="daily_checkin",
+        cron="0 9 * * *",
+        prompt_variant="daily_checkin_v1",
+    )
     callback(dummy_schedule)

--- a/device/src/main.py
+++ b/device/src/main.py
@@ -1,56 +1,49 @@
-
-import structlog
 import asyncio
+import structlog
+
+from . import ble_onboarding, firebase_client
+from .models import Schedule
+from .session_manager import SessionManager
 
 logger = structlog.get_logger()
 
-def is_wifi_configured():
-    """
-    Checks if the device is connected to a Wi-Fi network.
-    This is a placeholder and should be replaced with a real implementation.
-    """
+session_manager = SessionManager()
+
+
+def is_wifi_configured() -> bool:
+    """Return True if the device has Wi-Fi credentials configured."""
     # For now, we'll assume it's not configured
     return False
 
-from . import ble_onboarding
 
-def start_ble_onboarding():
-    """
-    Starts the BLE onboarding process.
-    """
+def start_ble_onboarding() -> None:
+    """Start the BLE onboarding process."""
     logger.info("Starting BLE onboarding...")
     asyncio.run(ble_onboarding.start_advertising())
 
-from . import firebase_client
 
-def run_normal_operation():
-    """
-    Starts the normal operation of the device agent.
-    """
+def run_normal_operation() -> None:
+    """Start the normal operation of the device agent."""
     logger.info("Starting normal operation...")
     if firebase_client.initialize_firebase():
         firebase_client.listen_for_schedules(handle_schedule)
 
-from . import session_manager
 
-def handle_schedule(schedule):
-    """
-    This function is called when a new schedule is received.
-    """
-    logger.info(f"Received schedule: {schedule}")
+def handle_schedule(schedule: Schedule) -> None:
+    """Handle a newly received schedule from Firestore."""
+    logger.info("Received schedule", schedule=schedule)
     session_manager.start_session(schedule)
 
-def main():
-    """
-    Main entry point for the device agent.
-    """
-    logger.info("Device agent starting up...")
 
+def main() -> None:
+    """Main entry point for the device agent."""
+    logger.info("Device agent starting up...")
     if is_wifi_configured():
         run_normal_operation()
     else:
         logger.info("Wi-Fi not configured.")
         start_ble_onboarding()
+
 
 if __name__ == "__main__":
     main()

--- a/device/src/models.py
+++ b/device/src/models.py
@@ -1,0 +1,24 @@
+from dataclasses import dataclass
+from typing import Optional
+
+
+@dataclass
+class OnboardingState:
+    """Tracks values received during BLE onboarding."""
+
+    ssid: Optional[str] = None
+    psk: Optional[str] = None
+    timezone: Optional[str] = None
+    claim_token: Optional[str] = None
+
+    def is_complete(self) -> bool:
+        return all([self.ssid, self.psk, self.timezone, self.claim_token])
+
+
+@dataclass
+class Schedule:
+    """Represents a scheduled check-in retrieved from Firestore."""
+
+    id: str
+    cron: str
+    prompt_variant: str

--- a/device/src/session_manager.py
+++ b/device/src/session_manager.py
@@ -1,85 +1,65 @@
-
 import structlog
+from .models import Schedule
 
-logger = structlog.get_logger()
 
-def start_session(schedule):
+class SessionManager:
+    """Coordinates the life-cycle of a conversation session.
+
+    The current implementation is intentionally lightweight but arranging
+    the behaviour into a class makes state management easier once
+    Firestore and the Realtime API are integrated for real.
     """
-    Starts a new session based on the given schedule.
-    """
-    logger.info(f"Starting session for schedule: {schedule}")
 
-    # 1. Create a session document in Firestore (placeholder)
-    session_id = create_firestore_session(schedule)
-    if not session_id:
-        return
+    def __init__(self) -> None:
+        self.logger = structlog.get_logger()
 
-    # 2. Connect to the OpenAI Realtime API (placeholder)
-    transcript = connect_to_openai(schedule)
-    if not transcript:
-        update_firestore_session(session_id, {"status": "failed"})
-        return
+    def start_session(self, schedule: Schedule) -> None:
+        """Start a session for the provided ``schedule``.
 
-    # 3. Save the transcript to Firestore (placeholder)
-    save_transcript(session_id, transcript)
+        The method demonstrates the expected flow of a session using
+        placeholder operations which can later be replaced by concrete
+        integrations.
+        """
 
-    # 4. Summarize the transcript (placeholder)
-    summary = summarize_transcript(transcript)
+        self.logger.info("Starting session for schedule", schedule=schedule)
 
-    # 5. Update the session document with the summary (placeholder)
-    update_firestore_session(session_id, {"summary": summary, "status": "completed"})
+        session_id = self._create_firestore_session(schedule)
+        if not session_id:
+            return
 
-    logger.info(f"Session completed for schedule: {schedule}")
+        transcript = self._connect_to_openai(schedule)
+        if not transcript:
+            self._update_firestore_session(session_id, {"status": "failed"})
+            return
 
-def create_firestore_session(schedule):
-    """
-    Creates a new session document in Firestore.
-    This is a placeholder implementation.
-    """
-    logger.info("Creating Firestore session...")
-    # In a real implementation, this would create a new document in the 'sessions' collection.
-    session_id = "test-session-id"
-    logger.info(f"Created Firestore session: {session_id}")
-    return session_id
+        self._save_transcript(session_id, transcript)
+        summary = self._summarize_transcript(transcript)
+        self._update_firestore_session(
+            session_id, {"summary": summary, "status": "completed"}
+        )
+        self.logger.info("Session completed", schedule=schedule)
 
-def connect_to_openai(schedule):
-    """
-    Connects to the OpenAI Realtime API and returns a transcript.
-    This is a placeholder implementation.
-    """
-    logger.info("Connecting to OpenAI Realtime API...")
-    # In a real implementation, this would use websockets to stream audio
-    # and receive the transcript.
-    transcript = "This is a test transcript."
-    logger.info("Received transcript from OpenAI.")
-    return transcript
+    # Placeholder implementations -------------------------------------------------
+    def _create_firestore_session(self, schedule: Schedule) -> str:
+        self.logger.info("Creating Firestore session")
+        session_id = "test-session-id"
+        self.logger.info("Created Firestore session", session_id=session_id)
+        return session_id
 
-def save_transcript(session_id, transcript):
-    """
-    Saves the transcript to Firestore.
-    This is a placeholder implementation.
-    """
-    logger.info(f"Saving transcript for session: {session_id}")
-    # In a real implementation, this would update the session document
-    # or create a new document in a 'transcripts' collection.
-    pass
+    def _connect_to_openai(self, schedule: Schedule) -> str:
+        self.logger.info("Connecting to OpenAI Realtime API")
+        transcript = "This is a test transcript."
+        self.logger.info("Received transcript from OpenAI")
+        return transcript
 
-def summarize_transcript(transcript):
-    """
-    Summarizes the transcript using an LLM.
-    This is a placeholder implementation.
-    """
-    logger.info("Summarizing transcript...")
-    # In a real implementation, this would make a call to a text LLM.
-    summary = "This is a test summary."
-    logger.info("Transcript summarized.")
-    return summary
+    def _save_transcript(self, session_id: str, transcript: str) -> None:
+        self.logger.info("Saving transcript", session_id=session_id)
 
-def update_firestore_session(session_id, data):
-    """
-    Updates the session document in Firestore.
-    This is a placeholder implementation.
-    """
-    logger.info(f"Updating Firestore session: {session_id}")
-    # In a real implementation, this would update the session document with the given data.
-    pass
+    def _summarize_transcript(self, transcript: str) -> str:
+        self.logger.info("Summarizing transcript")
+        summary = "This is a test summary."
+        self.logger.info("Transcript summarized")
+        return summary
+
+    def _update_firestore_session(self, session_id: str, data: dict) -> None:
+        self.logger.info("Updating Firestore session", session_id=session_id)


### PR DESCRIPTION
## Summary
- centralize onboarding and schedule types in a new `models` module
- convert BLE onboarding to use dataclass-backed state
- introduce `SessionManager` class and typed schedule handling in `main`

## Testing
- `python -m py_compile device/src/*.py`
- `npm test` *(fails: No test files found)*

------
https://chatgpt.com/codex/tasks/task_e_689abe242648832cb39f36b9f460fb2f